### PR TITLE
incorporate json wrapper for generating psi4 input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Instructions are provided below for following this example workflow.
 
 ## I. Python Dependencies
 
-  * [OEChem Python Toolkit](https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html)
-  * [Psi4 QM software package](http://www.psicode.org/)
-     * [Conda install](http://www.psicode.org/psi4manual/master/conda.html) of Psi4 recommended
-     * [Conda install of dftd3](http://www.psicode.org/psi4manual/master/dftd3.html)
+* Anaconda or Miniconda Python
+* [OEChem Python Toolkit](https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html)
+* [Psi4 QM software package](http://www.psicode.org/)
+   * [Conda install of Psi4](http://www.psicode.org/psi4manual/master/conda.html#detailed-installation-of-psifour)
+   * [Conda install of dftd3](http://www.psicode.org/psi4manual/master/dftd3.html)
+   * [(optional) Conda install of gcp](http://www.psicode.org/psi4manual/master/gcp.html)
 
 
 ## II. Repository contents
@@ -46,7 +48,7 @@ Pipeline components and description:
 | `diffSpeOpt.py`      | analysis      | compare how diff OPT energy is from pre-OPT single point energy            |
 | `executor.py`        | N/A           | main interface connecting "setup" and "results" scripts for Psi4           |
 | `filterConfs.py`     | setup/results | remover conformers of molecules that may be same structure                 |
-| `getPsiResults.py`   | results       | get job results from Psi4                                                  |
+| `get_psi_results.py` | results       | get job results from Psi4                                                  |
 | `getTurbResults.py`  | results       | get job results from Turbomole                                             |
 | `matchMinima.py`     | analysis      | match conformers from sets of different optimizations                      |
 | `match_plot.py`      | analysis      | additional plots that can be used from `matchMinima.py` results            |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Analysis scripts are provided for comparing conformer energies from different QM
  * Consider questions such as, "What is the spread of the conformer energies for molecule _x_?", "How does method _a_ compare to method _b_ for this molecule?", etc.
 
 In concept, this example would look like:   
-`smi2confs.py` &rarr; `confs2psi.py` &rarr; `filterConfs.py` &rarr; \[QM jobs\] &rarr; `filterConfs.py` &rarr; analysis
+`smi2confs.py` &rarr; `confs_to_psi.py` &rarr; `filterConfs.py` &rarr; \[QM jobs\] &rarr; `filterConfs.py` &rarr; analysis
 
 In practice, the `executor.py` code provides the interface for the various stages and components. 
 That being said, each component was written to be able to run independently of the others so variations of this pipeline can be conducted. 
@@ -43,7 +43,7 @@ Pipeline components and description:
 | Script               | Stage         | Brief description                                                          |
 | ---------------------|---------------|----------------------------------------------------------------------------|
 | `avgTimeEne.py`      | analysis      | analyze calculation stats and relative energies for a single batch of mols |
-| `confs2psi.py`       | setup         | generate Psi4 input files for each conformer/molecule                      |
+| `confs_to_psi.py`    | setup         | generate Psi4 input files for each conformer/molecule                      |
 | `confs2turb.py`      | setup         | generate Turbomole input files for each conformer/molecule                 |
 | `diffSpeOpt.py`      | analysis      | compare how diff OPT energy is from pre-OPT single point energy            |
 | `executor.py`        | N/A           | main interface connecting "setup" and "results" scripts for Psi4           |

--- a/examples/frozenAtoms/README.md
+++ b/examples/frozenAtoms/README.md
@@ -6,7 +6,7 @@ The SD tag can be added to the initial Quanformer-generated SDF file before runn
 (Not shown here but can be easily done/provided.)  
 This can be applied to conduct a QM torsion scan or similar.  
 
-An example script is provided to call the `confs2psi.py` script with the given SDF file.  
+An example script is provided to call the `confs_to_psi.py` script with the given SDF file.  
 This approach is equivalent to running: `python executor.py -f example.sdf --setup -t opt -m 'mp2' -b 'def2-SV(P)'`
 
 

--- a/examples/frozenAtoms/example.py
+++ b/examples/frozenAtoms/example.py
@@ -2,7 +2,7 @@
 import sys
 sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/01_scripts')
 
-import confs2psi
-confs2psi.confs2psi('example.sdf','mp2','def2-SV(P)')
+import confs_to_psi
+confs_to_psi.confs_to_psi('example.sdf','mp2','def2-SV(P)')
 
 

--- a/quanformer/confs2turb.py
+++ b/quanformer/confs2turb.py
@@ -3,7 +3,7 @@
 ## By: Victoria T. Lim
 
 ## Usage: python confs2turb.py -i /path/and/filename.sdf
-## Different from confs2psi.py since method, basisset, calc type, mem
+## Different from confs_to_psi.py since method, basisset, calc type, mem
 ##    should be specified in the templateOptions file of Turbomole setup.
 
 

--- a/quanformer/confs_to_psi.py
+++ b/quanformer/confs_to_psi.py
@@ -93,7 +93,7 @@ def make_psi_input(mol, label, method, basisset, calctype='opt', mem=None):
     return inputstring
 
 
-def confs2psi(insdf, method, basis, calctype='opt', memory=None):
+def confs_to_psi(insdf, method, basis, calctype='opt', memory=None):
     """
     Parameters
     ----------

--- a/quanformer/confs_to_psi.py
+++ b/quanformer/confs_to_psi.py
@@ -3,30 +3,45 @@
 """
 Purpose:    Generate Psi4 inputs for many molecules/conformers.
 By:         Victoria T. Lim, Christopher I. Bayly
-Version:    Oct 12 2018
+Version:    Nov 30 2018
 
 """
 
 import os, sys
 import openeye.oechem as oechem
 import shutil
+import json
 
 
 def make_psi_input(mol, label, method, basisset, calctype='opt', mem=None):
     """
+    Get coordinates from input mol, and generate/format input text for
+    Psi4 calculation.
+
     Parameters
     ----------
-    mol: single OEChem conformer with coordinates
-    label: string - name of the molecule. Can be an empty string.
-    method: string - specification of method (see Psi4 website for options)
-    basisset: string - specification of basis set
-    calctype: string - one of 'opt','spe','hess' for geometry optimization,
-        single point energy calculation, or Hessian calculation
-    mem: string - specify Psi4 job memory. E.g. "2 Gb" "2000 Mb" "2000000 Kb"
+    mol : OpenEye OEMol
+        OEMol with coordinates
+    label : string
+        Name of molecule with integer identifier (for conformers).
+    method: string
+        Name of the method as understood by Psi4. Example: "mp2"
+    basis : string
+        Name of the basis set as understood by Psi4. Example: "def2-sv(p)"
+    calctype : string
+        What kind of Psi4 calculation to run. Supported inputs are:
+        'opt' for geometry optimization,
+        'spe' for single point energy calculation, and
+        'hess' for Hessian calculation.
+    memory : string
+        How much memory each Psi4 job should take. If not specified, the
+        default in Psi4 is 500 Mb. Examples: "2000 MB" "1.5 GB"
+        http://www.psicode.org/psi4manual/master/psithoninput.html
 
     Returns
     -------
-    inputstring: string - containing contents of whole input file for this conf
+    inputstring : string
+        Contents of Psi4 input file to be written out
 
     """
 
@@ -35,7 +50,6 @@ def make_psi_input(mol, label, method, basisset, calctype='opt', mem=None):
         sys.exit("Specify a valid calculation type.")
 
     inputstring = ""
-    xyz = oechem.OEFloatArray(3)
 
     # specify memory requirements, if defined
     if mem != None:
@@ -46,7 +60,8 @@ def make_psi_input(mol, label, method, basisset, calctype='opt', mem=None):
     netCharge = oechem.OENetCharge( mol)
     inputstring+=( '  %s 1' % netCharge )
 
-    # get coordinates of each atom
+    # get atomic symbol and coordinates of each atom
+    xyz = oechem.OEFloatArray(3)
     for atom in mol.GetAtoms():
         mol.GetCoords( atom, xyz)
         inputstring+=( '\n  %s %10.4f %10.4f  %10.4f' \
@@ -93,17 +108,149 @@ def make_psi_input(mol, label, method, basisset, calctype='opt', mem=None):
     return inputstring
 
 
-def confs_to_psi(insdf, method, basis, calctype='opt', memory=None):
+def make_psi_json(mol, label, method, basisset, calctype='opt', mem=None):
     """
+    Get coordinates from input mol, and generate/format input text for
+    Psi4 calculation via JSON wrapper.
+
     Parameters
     ----------
-    insdf:  string - PATH+name of SDF file
-    method: string - method. E.g. "mp2"
-    basis:  string - basis set. E.g. "def2-sv(p)"
-    calctype: string - one of 'opt','spe','hess' for geometry optimization,
-                       single point energy calculation, or Hessian calculation
-    memory: string - memory specification. Psi4 default is 256 Mb. E.g. "1.5 Gb"
+    mol : OpenEye OEMol
+        OEMol with coordinates
+    label : string
+        Name of molecule with integer identifier (for conformers).
+    method: string
+        Name of the method as understood by Psi4. Example: "mp2"
+    basis : string
+        Name of the basis set as understood by Psi4. Example: "def2-sv(p)"
+    calctype : string
+        What kind of Psi4 calculation to run. Supported inputs are:
+        'opt' for geometry optimization,
+        'spe' for single point energy calculation, and
+        'hess' for Hessian calculation.
+    memory : string
+        How much memory each Psi4 job should take. If not specified, the
+        default in Psi4 is 500 Mb. Examples: "2000 MB" "1.5 GB"
+        http://www.psicode.org/psi4manual/master/psithoninput.html
 
+    Returns
+    -------
+    inputstring : string
+        Contents of Psi4 input file to be written out
+
+    """
+    # check that specified calctype is valid
+    if calctype not in {'opt','spe','hess'}:
+        sys.exit("Specify a valid calculation type.")
+
+    inputdict = {}
+    moldict = {}
+    modeldict = {}
+    keydict = {}
+    inputdict["schema_name"] = "qc_schema_input"
+    inputdict["schema_version"] = 1
+
+    # specify memory requirements, if defined
+    if mem != None:
+        inputdict["memory"] = mem
+
+    #TODO
+    # charge and multiplicity; multiplicity hardwired to singlet (usually is)
+    #inputdict["charge"] = oechem.OENetCharge( mol)
+    #inputdict["multiplicity"] = 1
+
+    # get atomic symbol and coordinates of each atom
+    geom_list = []
+    elem_list = []
+    xyz = oechem.OEFloatArray(3)
+    for atom in mol.GetAtoms():
+        mol.GetCoords( atom, xyz)
+        geom_list.append(xyz[0])
+        geom_list.append(xyz[1])
+        geom_list.append(xyz[2])
+        elem_list.append(oechem.OEGetAtomicSymbol(atom.GetAtomicNum()))
+    moldict["geometry"] = geom_list
+    moldict["symbols"] = elem_list
+    inputdict["molecule"] = moldict
+
+    #TODO
+    ## check if mol has a "freeze" tag
+    #for x in oechem.OEGetSDDataPairs(mol):
+    #    if calctype=="opt" and "atoms to freeze" in x.GetTag():
+    #        b = x.GetValue()
+    #        y = b.replace("[", "")
+    #        z = y.replace("]", "")
+    #        a = z.replace(" ", "")
+    #        freeze_list = a.split(",")
+    #        inputstring += ("\n\nfreeze_list = \"\"\"\n  {} xyz\n  {} xyz\n  {} "
+    #                       "xyz\n  {} xyz\n\"\"\"".format(freeze_list[0],
+    #                       freeze_list[1], freeze_list[2], freeze_list[3]))
+    #        inputstring += "\nset optking frozen_cartesian $freeze_list"
+    #        inputstring += ("\nset optking dynamic_level = 1\nset optking "
+    #            "consecutive_backsteps = 2\nset optking intrafrag_step_limit = "
+    #            "0.1\nset optking interfrag_step_limit = 0.1\n")
+
+    #TODO
+    ## explicitly specify MP2 RI-auxiliary basis for Ahlrichs basis set
+    ## http://www.psicode.org/psi4manual/master/basissets_byfamily.html
+    ## DFMP2 *should* get MP2 aux sets fine for Pople/Dunning
+    ## http://www.psicode.org/psi4manual/master/dfmp2.html
+    #if method.lower()=='mp2' and 'def2' in basisset:
+    #    if basisset.lower()=='def2-sv(p)':
+    #        inputstring+=('\nset df_basis_mp2 def2-sv_p_-ri')
+    #    elif basisset.lower()!='def2-qzvpd':  # no aux set for qzvpd 10-6-18
+    #        inputstring+=('\nset df_basis_mp2 %s-ri' % (basisset))
+
+    modeldict["basis"] = basisset
+    modeldict["method"] = method
+    inputdict["model"] = modeldict
+
+    #inputstring+=('\nset freeze_core True')
+    # specify command for type of calculation
+    if calctype=='opt':
+        # TODO
+        pass
+    elif calctype=='spe':
+        inputdict["driver"] = 'energy'
+    elif calctype=='hess':
+        inputdict["driver"] = 'hessian'
+        keydict["return_wfn"] = True
+    inputdict["keywords"] = keydict
+
+    return inputdict
+
+
+def confs_to_psi(insdf, method, basis, calctype='opt', memory=None, via_json=False):
+    """
+    Read in molecule(s) (and conformers, if present) in insdf file. Create
+    Psi4 input calculations for each structure.
+
+    Parameters
+    ----------
+    insdf: string
+        Name of the molecule file for which to create Psi4 input file.
+        SDF format can contain multiple molecules and multiple conformers per
+        molecule in a single file.
+    method: string
+        Name of the method as understood by Psi4. Example: "mp2"
+    basis : string
+        Name of the basis set as understood by Psi4. Example: "def2-sv(p)"
+    calctype : string
+        What kind of Psi4 calculation to run. Supported inputs are:
+        'opt' for geometry optimization,
+        'spe' for single point energy calculation, and
+        'hess' for Hessian calculation.
+    memory : string
+        How much memory each Psi4 job should take. If not specified, the
+        default in Psi4 is 500 Mb. Examples: "2000 MB" "1.5 GB"
+        http://www.psicode.org/psi4manual/master/psithoninput.html
+    via_json : Boolean
+        If True, use JSON wrapper for Psi4 input and output.
+        - Psi4 input would be in "input.py", called with python
+        - Psi4 output would be in "output.json"
+        If False, use normal text files for Psi4 input and output.
+        - Psi4 input would be in "input.dat"
+        - Psi4 output would be in "output.dat"
     """
     wdir = os.getcwd()
 
@@ -128,7 +275,17 @@ def confs_to_psi(insdf, method, basis, calctype='opt', memory=None):
                 print("Input file (\"input.dat\") already exists. Skipping.\n")
                 continue
             label = mol.GetTitle()+'_'+str(i+1)
-            ofile = open(os.path.join(subdir,'input.dat'), 'w')
-            ofile.write(make_psi_input( conf, label, method, basis, calctype, memory))
+            if via_json:
+                ofile = open(os.path.join(subdir,'input.py'), 'w')
+                ofile.write("# molecule {}\n\nimport numpy as np\nimport psi4"
+                            "\nimport json\n\njson_data = ".format(label))
+                json.dump(make_psi_json( conf, label, method, basis, calctype, memory), ofile, indent=4, separators=(',', ': '))
+                ofile.write("\njson_ret = psi4.json_wrapper.run_json(json_data)\n\n")
+                ofile.write("with open(\"output.json\", \"w\") as ofile:\n\t"
+                            "json.dump(json_ret, ofile, indent=2)\n\n")
+            else:
+                ofile = open(os.path.join(subdir,'input.dat'), 'w')
+                ofile.write(make_psi_input( conf, label, method, basis, calctype, memory))
             ofile.close()
     ifs.close()
+

--- a/quanformer/executor.py
+++ b/quanformer/executor.py
@@ -5,7 +5,7 @@ import argparse
 
 import smi2confs
 import filterConfs
-import confs2psi
+import confs_to_psi
 import get_psi_results
 
 def name_manager(infile):
@@ -53,7 +53,7 @@ def main(**kwargs):
 
         # generate Psi4 inputs
         print("\nCreating Psi4 input files for %s..." % prefix)
-        confs2psi.confs2psi(post_filt,opt['method'],opt['basisset'],opt['calctype'],opt['mem'])
+        confs_to_psi.confs_to_psi(post_filt,opt['method'],opt['basisset'],opt['calctype'],opt['mem'])
 
 
     else:  # ========== AFTER QM =========== #

--- a/quanformer/executor.py
+++ b/quanformer/executor.py
@@ -6,7 +6,7 @@ import argparse
 import smi2confs
 import filterConfs
 import confs2psi
-import getPsiResults
+import get_psi_results
 
 def name_manager(infile):
     curr_dir = os.getcwd()
@@ -79,12 +79,12 @@ def main(**kwargs):
 
         # get psi4 results
         print("Getting Psi4 results for %s ..." %(checked_infile))
-        method, basisset = getPsiResults.getPsiResults(checked_infile, out_results, calctype=opt['calctype'])
+        method, basisset = get_psi_results.get_psi_results(checked_infile, out_results, calctype=opt['calctype'])
 
         # only filter structures after opts; spe/hess should not change geoms
         if opt['calctype'] == 'opt':
 
-            # if didn't go through getPsiResults (e.g., output file already exists)
+            # if didn't go through get_psi_results (e.g., output file already exists)
             # then look for method from command line call for filtering
             if None in [method, basisset]:
                 if None in [opt['method'], opt['basisset']]:

--- a/quanformer/get_psi_results.py
+++ b/quanformer/get_psi_results.py
@@ -262,7 +262,7 @@ def process_psi_out(filename, properties, calctype='opt'):
 
 ### ------------------- Script -------------------
 
-def getPsiResults(origsdf, finsdf, calctype='opt', psiout="output.dat", timeout="timer.dat"):
+def get_psi_results(origsdf, finsdf, calctype='opt', psiout="output.dat", timeout="timer.dat"):
 
     """
     Read in OEMols (and each of their conformers) in origsdf file,
@@ -443,5 +443,5 @@ def getPsiOne(infile, outfile, calctype='opt', psiout="output.dat", timeout="tim
 
 
 if __name__ == "__main__":
-    getPsiResults(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+    get_psi_results(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
 

--- a/quanformer/quan2modsem.py
+++ b/quanformer/quan2modsem.py
@@ -116,7 +116,7 @@ def quan2modsem(infile, pfile):
             # set file locations; dir for modsem needs / at end of string
             datadir = os.path.join(hdir,"%s/%s/" % (mol.GetTitle(),j+1))
 
-            # extract hessian from the quanformer-generated dictionary (getPsiResults)
+            # extract hessian from the quanformer-generated dictionary (get_psi_results)
             hessian = hdict[mol.GetTitle()][j+1]
 
             # run modsem

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,12 +7,12 @@ Last updated: Oct 22 2018
 |--------------------------------|----------------------|----------------------------------------------------------------------------------------------|
 | `carbon-222.sdf`,`t1`,`s1`     | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/work_hydrocarbons/HESS`                   |
 | `cooh`                         | `getTurbResults.py`  | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/work_coohDirection/02_torsion/03_Turbomole/2_solv-HF` 
-| `freeze.sdf`                   | `confs2psi.py`       | `/data11/home/jmaat/off_nitrogens/sdf_min/sdf_min_mol2/pyrnit_2_constituent_11_improper.sdf` |
+| `freeze.sdf`                   | `confs_to_psi.py`    | `/data11/home/jmaat/off_nitrogens/sdf_min/sdf_min_mol2/pyrnit_2_constituent_11_improper.sdf` |
 | `GBI`                          | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/GBI`                     |
 | `gbi-200.sdf`,`gbi_single.sdf` | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/examples2-200.sdf`       |
 | `gbi.sdf`                      | `filterConfs.py`     | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/examples2.sdf`           |
 | `methane.smi`                  | `smi2confs.py`       | self-generated                                                                               |
-| `methane_c2p.sdf`              | `confs2psi.py`       | `test_smi2confs()`                                                                           |
+| `methane_c2p.sdf`              | `confs_to_psi.py`    | `test_smi2confs()`                                                                           |
 | `output_hess.dat`              | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/hessian/sandbox_benzene/benzene/output.dat`        |
 | `output_opt.dat`, `timer.dat`  | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/GBI/1/`                  |
 | `output_spe.dat`               | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/set1_01_main/SPE1/AlkEthOH_c1178/1/output.dat` |

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,17 +3,17 @@
 Notes for VTL.  
 Last updated: Oct 22 2018
 
-| filename                       | test script        | source                                                                                       |
-|--------------------------------|--------------------|----------------------------------------------------------------------------------------------|
-| `carbon-222.sdf`,`t1`,`s1`     | `getPsiResults.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/work_hydrocarbons/HESS`                   |
-| `cooh`                         | `getTurbResults.py`| `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/work_coohDirection/02_torsion/03_Turbomole/2_solv-HF` 
-| `freeze.sdf`                   | `confs2psi.py`     | `/data11/home/jmaat/off_nitrogens/sdf_min/sdf_min_mol2/pyrnit_2_constituent_11_improper.sdf` |
-| `GBI`                          | `getPsiResults.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/GBI`                     |
-| `gbi-200.sdf`,`gbi_single.sdf` | `getPsiResults.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/examples2-200.sdf`       |
-| `gbi.sdf`                      | `filterConfs.py`   | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/examples2.sdf`           |
-| `methane.smi`                  | `smi2confs.py`     | self-generated                                                                               |
-| `methane_c2p.sdf`              | `confs2psi.py`     | `test_smi2confs()`                                                                           |
-| `output_hess.dat`              | `getPsiResults.py` | `/beegfs/DATA/mobley/limvt/openforcefield/hessian/sandbox_benzene/benzene/output.dat`        |
-| `output_opt.dat`, `timer.dat`  | `getPsiResults.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/GBI/1/`                  |
-| `output_spe.dat`               | `getPsiResults.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/set1_01_main/SPE1/AlkEthOH_c1178/1/output.dat` |
+| filename                       | test script          | source                                                                                       |
+|--------------------------------|----------------------|----------------------------------------------------------------------------------------------|
+| `carbon-222.sdf`,`t1`,`s1`     | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/work_hydrocarbons/HESS`                   |
+| `cooh`                         | `getTurbResults.py`  | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/work_coohDirection/02_torsion/03_Turbomole/2_solv-HF` 
+| `freeze.sdf`                   | `confs2psi.py`       | `/data11/home/jmaat/off_nitrogens/sdf_min/sdf_min_mol2/pyrnit_2_constituent_11_improper.sdf` |
+| `GBI`                          | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/GBI`                     |
+| `gbi-200.sdf`,`gbi_single.sdf` | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/examples2-200.sdf`       |
+| `gbi.sdf`                      | `filterConfs.py`     | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/examples2.sdf`           |
+| `methane.smi`                  | `smi2confs.py`       | self-generated                                                                               |
+| `methane_c2p.sdf`              | `confs2psi.py`       | `test_smi2confs()`                                                                           |
+| `output_hess.dat`              | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/hessian/sandbox_benzene/benzene/output.dat`        |
+| `output_opt.dat`, `timer.dat`  | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/03_examples/set1/GBI/1/`                  |
+| `output_spe.dat`               | `get_psi_results.py` | `/beegfs/DATA/mobley/limvt/openforcefield/pipeline/set1_01_main/SPE1/AlkEthOH_c1178/1/output.dat` |
 

--- a/tests/test_confs_to_psi.py
+++ b/tests/test_confs_to_psi.py
@@ -49,10 +49,10 @@ def test_make_dfmp2_svpp():
     return
 
 def test_confs_to_psi():
+    shutil.rmtree('methane')
     confs_to_psi(os.path.join(mydir,'data_tests','methane_c2p.sdf'),'mp2','def2-sv(p)')
     # check file byte size (this line should be updated if confs_to_psi changes)
     assert os.path.getsize(os.path.join(mydir,'methane','1','input.dat')) == 327
-    shutil.rmtree('methane')
     return
 
 

--- a/tests/test_confs_to_psi.py
+++ b/tests/test_confs_to_psi.py
@@ -49,10 +49,11 @@ def test_make_dfmp2_svpp():
     return
 
 def test_confs_to_psi():
-    shutil.rmtree('methane')
     confs_to_psi(os.path.join(mydir,'data_tests','methane_c2p.sdf'),'mp2','def2-sv(p)')
     # check file byte size (this line should be updated if confs_to_psi changes)
     assert os.path.getsize(os.path.join(mydir,'methane','1','input.dat')) == 327
+    # pytest can't find file during assert, even though rmtree is after assert
+    #shutil.rmtree('methane')
     return
 
 

--- a/tests/test_confs_to_psi.py
+++ b/tests/test_confs_to_psi.py
@@ -51,8 +51,8 @@ def test_make_dfmp2_svpp():
 def test_confs_to_psi():
     confs_to_psi(os.path.join(mydir,'data_tests','methane_c2p.sdf'),'mp2','def2-sv(p)')
     # check file byte size (this line should be updated if confs_to_psi changes)
-    assert os.path.getsize(os.path.join(mydir,'methane','1','input.dat')) == 327
-    # pytest can't find file during assert, even though rmtree is after assert
+    #assert os.path.getsize(os.path.join(mydir,'methane','1','input.dat')) == 327
+    assert os.path.getsize(os.path.join('methane','1','input.dat')) == 327
     #shutil.rmtree('methane')
     return
 

--- a/tests/test_confs_to_psi.py
+++ b/tests/test_confs_to_psi.py
@@ -51,12 +51,18 @@ def test_make_dfmp2_svpp():
 def test_confs_to_psi():
     confs_to_psi(os.path.join(mydir,'data_tests','methane_c2p.sdf'),'mp2','def2-sv(p)')
     # check file byte size (this line should be updated if confs_to_psi changes)
-    #assert os.path.getsize(os.path.join(mydir,'methane','1','input.dat')) == 327
     assert os.path.getsize(os.path.join('methane','1','input.dat')) == 327
+    shutil.rmtree('methane')
+    return
+
+def test_confs_to_psi_json():
+    confs_to_psi(os.path.join(mydir,'data_tests','methane_c2p.sdf'),
+                'mp2','def2-sv(p)',calctype='spe',via_json=True)
+    # check file byte size (this line should be updated if confs_to_psi changes)
+    assert os.path.getsize(os.path.join('methane','1','input.py')) == 1032
     #shutil.rmtree('methane')
     return
 
-
 # test manually without pytest
 if 0:
-    test_confs_to_psi()
+    test_confs_to_psi_json()

--- a/tests/test_confs_to_psi.py
+++ b/tests/test_confs_to_psi.py
@@ -49,8 +49,13 @@ def test_make_dfmp2_svpp():
     return
 
 def test_confs_to_psi():
+    confs_to_psi(os.path.join(mydir,'data_tests','methane_c2p.sdf'),'mp2','def2-sv(p)')
+    # check file byte size (this line should be updated if confs_to_psi changes)
+    assert os.path.getsize(os.path.join(mydir,'methane','1','input.dat')) == 327
+    shutil.rmtree('methane')
     return
+
 
 # test manually without pytest
 if 0:
-    test_make_hessian()
+    test_confs_to_psi()

--- a/tests/test_confs_to_psi.py
+++ b/tests/test_confs_to_psi.py
@@ -1,11 +1,11 @@
 
 # local testing vs. travis testing
 try:
-    from quanformer.confs2psi import *
+    from quanformer.confs_to_psi import *
 except ModuleNotFoundError:
     import sys
-    sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/github/quanformer')
-    from confs2psi import *
+    sys.path.insert(0, '/home/limvt/Documents/off_psi4/quanformer')
+    from confs_to_psi import *
 
 # define location of input files for testing
 import os
@@ -48,7 +48,7 @@ def test_make_dfmp2_svpp():
     assert "def2-sv_p_-ri" in test_string
     return
 
-def test_confs2psi():
+def test_confs_to_psi():
     return
 
 # test manually without pytest

--- a/tests/test_filterConfs.py
+++ b/tests/test_filterConfs.py
@@ -4,7 +4,7 @@ try:
     from quanformer.filterConfs import *
 except ModuleNotFoundError:
     import sys
-    sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/github/quanformer')
+    sys.path.insert(0, '/home/limvt/Documents/off_psi4/quanformer')
     from filterConfs import *
 
 # define location of input files for testing

--- a/tests/test_getTurbResults.py
+++ b/tests/test_getTurbResults.py
@@ -4,7 +4,7 @@ try:
     from quanformer.getTurbResults import *
 except ModuleNotFoundError:
     import sys
-    sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/github/quanformer')
+    sys.path.insert(0, '/home/limvt/Documents/off_psi4/quanformer')
     from getTurbResults import *
 
 # define location of input files for testing

--- a/tests/test_get_psi_results.py
+++ b/tests/test_get_psi_results.py
@@ -1,11 +1,11 @@
 
 # local testing vs. travis testing
 try:
-    from quanformer.getPsiResults import *
+    from quanformer.get_psi_results import *
 except ModuleNotFoundError:
     import sys
     sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/github/quanformer')
-    from getPsiResults import *
+    from get_psi_results import *
 
 # define location of input files for testing
 import os
@@ -87,23 +87,23 @@ def test_getPsiOne():
     os.remove(outfile)
 
 # TODO
-#def test_getPsiResults_none(capsys):
+#def test_get_psi_results_none(capsys):
 #    infile = os.path.join(mydir,'data_tests','gbi-200.sdf')
 #    outfile = os.path.join(mydir,'data_tests','gbi-210.sdf')
 #    with pytest.raises(SystemExit):
-#        m, b = getPsiResults(infile, outfile, calctype='blah', psiout="output.dat", timeout="timer.dat")
+#        m, b = get_psi_results(infile, outfile, calctype='blah', psiout="output.dat", timeout="timer.dat")
 #    out, err = capsys.readouterr()
 #    assert err == "Specify a valid calculation type."
 #    print(out, err)
 
-def test_getPsiResults_spe():
+def test_get_psi_results_spe():
     # TODO
     pass
 
-def test_getPsiResults_hess():
+def test_get_psi_results_hess():
     infile = os.path.join(mydir,'data_tests','carbon-222.sdf')
     outfile = os.path.join(mydir,'data_tests','carbon_hess-222.sdf')
-    m, b = getPsiResults(infile, outfile, 'hess', "output.dat", "timer.dat")
+    m, b = get_psi_results(infile, outfile, 'hess', "output.dat", "timer.dat")
     # check the method and basis set returned
     assert m == 'mp2'
     assert b == 'def2-tzvp'
@@ -126,10 +126,10 @@ def test_getPsiResults_hess():
     os.remove(hpickle)
 
 
-def test_getPsiResults_opt():
+def test_get_psi_results_opt():
     infile = os.path.join(mydir,'data_tests','gbi-200.sdf')
     outfile = os.path.join(mydir,'data_tests','gbi-210.sdf')
-    m, b = getPsiResults(infile, outfile, 'opt', "output.dat", "timer.dat")
+    m, b = get_psi_results(infile, outfile, 'opt', "output.dat", "timer.dat")
     assert m == 'mp2'
     assert b == 'def2-SV(P)'
 
@@ -153,6 +153,6 @@ def test_getPsiResults_opt():
 # test manually without pytest
 if 0:
     #test_getPsiOne()
-    #test_getPsiResults_none()
-    test_getPsiResults_hess()
+    #test_get_psi_results_none()
+    test_get_psi_results_hess()
 

--- a/tests/test_get_psi_results.py
+++ b/tests/test_get_psi_results.py
@@ -4,7 +4,7 @@ try:
     from quanformer.get_psi_results import *
 except ModuleNotFoundError:
     import sys
-    sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/github/quanformer')
+    sys.path.insert(0, '/home/limvt/Documents/off_psi4/quanformer')
     from get_psi_results import *
 
 # define location of input files for testing

--- a/tests/test_procTags.py
+++ b/tests/test_procTags.py
@@ -4,7 +4,7 @@ try:
     from quanformer.procTags import *
 except ModuleNotFoundError:
     import sys
-    sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/github/quanformer')
+    sys.path.insert(0, '/home/limvt/Documents/off_psi4/quanformer')
     from procTags import *
 
 # define location of input files for testing

--- a/tests/test_smi2confs.py
+++ b/tests/test_smi2confs.py
@@ -4,7 +4,7 @@ try:
     from quanformer.smi2confs import *
 except ModuleNotFoundError:
     import sys
-    sys.path.insert(0, '/beegfs/DATA/mobley/limvt/openforcefield/pipeline/github/quanformer')
+    sys.path.insert(0, '/home/limvt/Documents/off_psi4/quanformer')
     from smi2confs import *
 
 # define location of input files for testing


### PR DESCRIPTION
Did not go further to process JSON output files, nor specify specific settings for JSON input file (charge, multiplicity, frozen atoms, etc.) Not sure if the wrapper has those capabilities based on going through all the examples in the psi4 repo. Addresses part of #7.